### PR TITLE
Calibration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ignore the generated html documentation for the purposes of
+# language percentages for Linguist
+www/html/* linguist-documentation

--- a/programs/45-Utils/02-ABSIMU_calibrate.py
+++ b/programs/45-Utils/02-ABSIMU_calibrate.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2016 mindsensors.com
+# 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+#mindsensors.com invests time and resources providing this open source code, 
+#please support mindsensors.com  by purchasing products from mindsensors.com!
+#Learn more product option visit us @  http://www.mindsensors.com/
+#
+# History:
+# Date       Author          Comments
+# 04/21/17   Seth Tenembaum  Initial development.
+#
+
+import os, time
+from mindsensorsUI import mindsensorsUI
+from mindsensors_i2c import mindsensors_i2c
+from PiStormsCom import PiStormsCom
+from PiStormsCom import PSSensor
+
+
+s = mindsensorsUI() # screen
+psc = PiStormsCom()
+i2c = mindsensors_i2c(0x22 >> 1)
+
+PSSensor(psc.bankA, 1).activateCustomSensorI2C()
+
+s.drawDisplay("ABSIMU Calibration")
+
+s.termGotoLine(0)
+s.termPrintln("Beginning AbsoluteIMU compass")
+s.termPrintln("calibration program.")
+s.termPrintln("")
+s.termPrintln("Connect AbsoluteIMU-ACG")
+s.termPrintln("to BAS1.")
+s.termPrintln("")
+s.termReplaceLastLine("Press GO to begin.")
+
+startKeyPressCount = psc.getKeyPressCount()
+while psc.getKeyPressCount() == startKeyPressCount: time.sleep(0.1)
+
+i2c.writeByte(psc.PS_Command, ord('C'))
+
+
+s.clearScreen()
+s.dumpTerminal()
+s.termGotoLine(0)
+s.termPrintln("Calibrating...")
+s.termPrintln("Turn 360 degrees")
+s.termPrintln("along all 3 axes.")
+s.termPrintln("")
+s.termReplaceLastLine("Then press GO to end.")
+
+startKeyPressCount = psc.getKeyPressCount()
+while psc.getKeyPressCount() == startKeyPressCount: time.sleep(0.1)
+
+i2c.writeByte(psc.PS_Command, ord('c'))
+

--- a/programs/utils/01-Calibrate.py
+++ b/programs/utils/01-Calibrate.py
@@ -42,7 +42,8 @@ if PiStormsCom().GetFirmwareVersion() < 'V2.10':
 # Setup #
 #########
 
-os.system("/etc/init.d/MSBrowser.sh stop") # stop browser to avoid race conditions
+# the browser needs to be stopped and restarted to read the new touchscreen values when calibration finishes
+os.system("/etc/init.d/MSBrowser.sh stop")
 
 # avoid 'Failed to read touchscreen calibration values' popup from mindsensorsUI if the touchscreen calibration values cache file doesn't exist
 if not os.path.isfile('/tmp/ps_ts_cal'):
@@ -85,8 +86,7 @@ if not (len(sys.argv) > 1 and str(sys.argv[1]) == "force"):
         countdown = countdown - 1
 
     if psc.getKeyPressCount() == startKeyPressCount:
-        os.system("sudo /etc/init.d/MSBrowser.sh start &")
-        sys.exit(0)
+        sys.exit(0) # note: MSBrowser will automatically restart
 
 s.clearScreen()
 s.dumpTerminal()
@@ -195,5 +195,4 @@ else:
     print 'Error writing calibration values to PiStorms'
     s.showMessage(['Error', 'Failed to write calibration values', 'to PiStorms'])
 
-# the browser needs to be restarted so it will read the new touchscreen values
-os.system("/etc/init.d/MSBrowser.sh start &")
+# note: MSBrowser will automatically restart

--- a/programs/utils/01-Calibrate.py
+++ b/programs/utils/01-Calibrate.py
@@ -42,6 +42,8 @@ if PiStormsCom().GetFirmwareVersion() < 'V2.10':
 # Setup #
 #########
 
+os.system("/etc/init.d/MSBrowser.sh stop") # stop browser to avoid race conditions
+
 # avoid 'Failed to read touchscreen calibration values' popup from mindsensorsUI if the touchscreen calibration values cache file doesn't exist
 if not os.path.isfile('/tmp/ps_ts_cal'):
     open('/tmp/ps_ts_cal', 'w').write('{}')
@@ -192,3 +194,6 @@ if all([ calibrationEqual(offset, value) for offset, value in enumerate([x1,y1,x
 else:
     print 'Error writing calibration values to PiStorms'
     s.showMessage(['Error', 'Failed to write calibration values', 'to PiStorms'])
+
+# the browser needs to be restarted so it will read the new touchscreen values
+os.system("/etc/init.d/MSBrowser.sh start &")


### PR DESCRIPTION
- Add AbsoluteIMU compass calibration program

- Stop browser program before starting calibration program. Previously, if the "Calibrate" button was clicked from the web interface, the calibration program would start but the browser would still be running. Both programs trying to write to the screen at the same time would cause problems.