### PR TITLE
Show logo on startup using only Adafruit libraries

### DIFF
--- a/programs/utils/show-logo.py
+++ b/programs/utils/show-logo.py
@@ -1,0 +1,9 @@
+# Displays mindsensors.com logo only using Adafruit libraries.
+# If I2c isn't working, this will still be able to display the image (over SPI).
+
+from Adafruit_ILI9341 import ILI9341 as TFT
+from Adafruit_GPIO import SPI
+import Image
+
+disp = TFT(24, rst=25, spi=SPI.SpiDev(0,0,max_speed_hz=64000000))
+disp.display(Image.open("/usr/local/mindsensors/images/ms-logo-w320-h240.png").rotate(90))

--- a/setup/MSDriver.sh
+++ b/setup/MSDriver.sh
@@ -34,7 +34,7 @@ show_logo() {
     echo "config file is missing"
     homefolder=/home/pi/PiStorms
   fi
-  python $homefolder/programs/utils/img-to-screen.py 0 0 320 240 /usr/local/mindsensors/images/ms-logo-w320-h240.png
+  python $homefolder/programs/utils/show-logo.py
 
 }
 


### PR DESCRIPTION
Now the mindsensors.com logo will display even if I2C isn't working, verifying SPI is working.